### PR TITLE
fix: separate registry hostname from full path for docker login

### DIFF
--- a/.github/actions/setup-container-cache-registry/action.yml
+++ b/.github/actions/setup-container-cache-registry/action.yml
@@ -8,8 +8,11 @@ inputs:
 
 outputs:
   ci-cache-registry:
-    description: 'Container registry URL to use for this workflow run'
+    description: 'Container registry URL to use for this workflow run (includes namespace)'
     value: ${{ steps.set-registry.outputs.ci-cache-registry }}
+  ci-cache-registry-hostname:
+    description: 'Container registry hostname for login (e.g., ghcr.io)'
+    value: ${{ steps.set-registry.outputs.ci-cache-registry-hostname }}
   is-fork-pr:
     description: 'Whether this is a PR from a forked repository'
     value: ${{ steps.set-registry.outputs.is-fork-pr }}
@@ -58,8 +61,17 @@ runs:
           echo "Internal event - using org registry: $REGISTRY"
         fi
         
+        # Extract registry hostname from full registry path
+        # Examples:
+        # - ghcr.io/owner/repo -> ghcr.io
+        # - docker.io/myorg/myrepo -> docker.io
+        # - myregistry.com:5000/path -> myregistry.com:5000
+        # - ghcr.io -> ghcr.io (no path)
+        REGISTRY_HOSTNAME=$(echo "$REGISTRY" | cut -d'/' -f1)
+        
         # Output for use in other jobs
         echo "ci-cache-registry=$REGISTRY" >> $GITHUB_OUTPUT
+        echo "ci-cache-registry-hostname=$REGISTRY_HOSTNAME" >> $GITHUB_OUTPUT
         echo "is-fork-pr=$IS_FORK_PR" >> $GITHUB_OUTPUT
         
         # Brief summary for workflow run visibility

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       ci-cache-registry: ${{ steps.setup-registry.outputs.ci-cache-registry }}
+      ci-cache-registry-hostname: ${{ steps.setup-registry.outputs.ci-cache-registry-hostname }}
       is-fork-pr: ${{ steps.setup-registry.outputs.is-fork-pr }}
     steps:
       - uses: actions/checkout@v4
@@ -190,7 +191,7 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry }}
+          registry: ${{ needs.setup-container-cache-registry.outputs.ci-cache-registry-hostname }}
           username: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_USERNAME || github.actor }}
           password: ${{ secrets.DOCKER_CICD_CACHE_REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Docker login requires just the registry hostname (e.g., ghcr.io) not the full path with namespace. This fix extracts the hostname dynamically to support any registry configuration including custom registries.

Changes:
- Add ci-cache-registry-hostname output to setup-container-cache-registry
- Extract hostname from full registry path (handles ghcr.io, docker.io, custom registries)
- Use hostname for docker login, full path for image tags

## Checklist

- [ ] Follow the [contributor guide](./CONTRIBUTING.md)
- [ ] End-to-end tests pass
- [ ] Unit tests for essential parts of your code, e.g. APIs exposed via SDKs or endpoints
- [ ] Update `./docs`
- [ ] Recognize contributors with "@all-contributors please add <person> for <code, bug, docs, etc>"
- [ ] Linked issues #eg101 